### PR TITLE
fix(discord): disconnect cleanup and disable-state UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           channel: stable
       - run: |
           sudo apt-get update
-          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev libmpv-dev
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev libmpv-dev libmimalloc-dev
       - run: flutter pub get
       - run: flutter build linux
       

--- a/lib/pages/settings/settings_page.dart
+++ b/lib/pages/settings/settings_page.dart
@@ -22,6 +22,7 @@ class _SettingsPageState extends State<SettingsPage> {
   final _delimiterCtrl = TextEditingController();
 
   //discord RPC state
+  bool _discordConnected = false;
   bool _discordEnabled = false;
   String? _discordUsername;
   bool _discordLoading = false;
@@ -55,14 +56,15 @@ class _SettingsPageState extends State<SettingsPage> {
 
   Future<void> _loadDiscord() async {
     final rpc = DiscordRpcService.instance;
+    final connected = rpc.isConnected;
     final enabled = rpc.isEnabled;
     String? username;
-    if (enabled) {
-      final stored = await widget.db.getSetting('discord.username');
-      username = stored;
+    if (connected) {
+      username = await widget.db.getSetting('discord.username');
     }
     if (mounted) {
       setState(() {
+        _discordConnected = connected;
         _discordEnabled = enabled;
         _discordUsername = username;
       });
@@ -82,6 +84,7 @@ class _SettingsPageState extends State<SettingsPage> {
       await widget.db.setSetting('discord.username', '@${user.username}');
       if (mounted) {
         setState(() {
+          _discordConnected = true;
           _discordEnabled = true;
           _discordUsername = '@${user.username}';
           _discordLoading = false;
@@ -99,9 +102,9 @@ class _SettingsPageState extends State<SettingsPage> {
 
   Future<void> _discordLogout() async {
     await DiscordRpcService.instance.logout();
-    await widget.db.removeSetting('discord.username');
     if (mounted) {
       setState(() {
+        _discordConnected = false;
         _discordEnabled = false;
         _discordUsername = null;
       });
@@ -290,7 +293,7 @@ class _SettingsPageState extends State<SettingsPage> {
             padding: EdgeInsets.symmetric(vertical: 16),
             child: Center(child: CircularProgressIndicator()),
           )
-        else if (_discordEnabled) ...[
+        else if (_discordConnected) ...[
           ListTile(
             contentPadding: EdgeInsets.zero,
             title: Text(_discordUsername ?? 'Connected'),

--- a/lib/services/discord_rpc/discord_rpc_service.dart
+++ b/lib/services/discord_rpc/discord_rpc_service.dart
@@ -101,17 +101,32 @@ class DiscordRpcService {
 
   /// Disconnect discord rpc
   Future<void> logout() async {
-    await _clearPresence();
     _stop();
-    _tokenManager?.clear();
+
+    try {
+      await _clearPresence();
+    } catch (_) {}
+
+    final tm = _tokenManager;
     _tokenManager = null;
+    if (tm != null) {
+      await tm.clear();
+      tm.dispose();
+    }
+
     _userToken = null;
+    _sessionToken = null;
     _enabled = false;
+    _rateLimitUntil = null;
+    _externalImageCache.clear();
 
     final db = _db;
     if (db != null) {
       await db.removeSetting('discord.token');
-      await db.setSetting('discord.enabled', 'false');
+      await db.removeSetting('discord.access_token');
+      await db.removeSetting('discord.session_token');
+      await db.removeSetting('discord.username');
+      await db.removeSetting('discord.enabled');
     }
   }
 
@@ -375,7 +390,7 @@ class DiscordRpcService {
       if (kDebugMode) print('Discord RPC: failed to clear: $e');
     }
     _sessionToken = null;
-    _db?.removeSetting('discord.session_token');
+    await _db?.removeSetting('discord.session_token');
   }
 
   void dipose() {

--- a/lib/services/discord_rpc/discord_rpc_service.dart
+++ b/lib/services/discord_rpc/discord_rpc_service.dart
@@ -42,6 +42,9 @@ class DiscordRpcService {
   /// Wether RPC is currently active
   bool get isEnabled => _enabled;
 
+  /// Wether a discord token is loaded (user logged in)
+  bool get isConnected => _userToken != null;
+
   /// Raw dsc usr token, if logged in. stored in settings db
   String? _userToken;
 

--- a/lib/services/discord_rpc/token_manager.dart
+++ b/lib/services/discord_rpc/token_manager.dart
@@ -55,9 +55,9 @@ class DiscordTokenManager {
     return _accessToken!;
   }
 
-  void clear() {
+  Future<void> clear() async {
     _accessToken = null;
-    deleteCache('discord_access_token');
+    await deleteCache('discord_access_token');
   }
 
   void dispose() => _client.close();


### PR DESCRIPTION
Fixes two Discord RPC bugs.

### Toggling "Enabled" off showed the "Not connected" card

The settings panel branched on `_discordEnabled` for both *is logged in* and *is the switch on*, so turning the switch off unmounted the whole panel. Split into `_discordConnected` and `_discordEnabled`, and added an `isConnected` getter on the service.

 ### Disconnect left stale state behind

`logout()` didn‘t fully clean up, which could surface as `Failed to get user details: 401` on the next login. Three issues:

- `TokenManger.clear()` was sync fire-and-forget, so `discord.access_token` could still be on disk when reconnecting
- `discord.session_token` was only removed inside `_clearPresence()` after its early-return guard
- `_clearPresence()` ran before `_stop()`, letting a debounce timer race with teardown on `_tokenManager!`

Reordered teardown (stop > clear presence > tear down token manager), made `TokenManager.clear()` awaitable, and now unconditionally wipes every `discord.*` key. Moved `discord.username` cleanup from the UI into the service so there‘s a single owner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discord connection status tracking to more accurately reflect whether the service is connected.
  * Enhanced Discord logout process to ensure complete cleanup of authentication data and session information.
  * Fixed token management to properly handle asynchronous cache removal during logout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->