### PR TITLE
build(linux): use find_library for mimalloc instead of pkg-config

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -61,9 +61,8 @@ add_subdirectory("runner")
 add_dependencies(${BINARY_NAME} flutter_assemble)
 
 # Use mimalloc to avoid memory fragmentation with mpv
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(MIMALLOC REQUIRED IMPORTED_TARGET mimalloc)
-target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::MIMALLOC)
+find_library(MIMALLOC_LIBRARY NAMES mimalloc REQUIRED)
+target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIBRARY})
 
 # Only the install-generated bundle's copy of the executable will launch
 # correctly, since the resources must in the right relative locations. To avoid


### PR DESCRIPTION
ubuntu's libmimalloc-dev does not ship mimalloc.pc, so pkg_check_modules fails on ci even with the package installed. find_library looks up libmimalloc.so directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration for dependency resolution on Linux platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->