### PR TITLE
ci: add a Build APK workflow with some options

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,127 @@
+name: Build APK
+
+on:
+  workflow_dispatch:
+    inputs:
+      flavor:
+        description: Product flavor
+        type: choice
+        default: prod
+        options: [prod, dev, play]
+      mode:
+        description: Build mode
+        type: choice
+        default: release
+        options: [release, profile, debug]
+      sign:
+        description: Sign release builds with the upload keystore
+        type: boolean
+        default: true
+      build_name:
+        description: Version name override, empty uses pubspec
+        type: string
+        default: ""
+      build_number:
+        description: Version code override, empty uses pubspec
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: apk-${{ github.ref }}-${{ inputs.flavor }}-${{ inputs.mode }}
+  cancel-in-progress: true
+
+jobs:
+  apk:
+    runs-on: ubuntu-latest
+    env:
+      HAS_KEYSTORE: ${{ secrets.KEYSTORE_BASE64 != '' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - run: flutter pub get
+      - run: dart run scripts/compute_translation_progress.dart
+
+      - name: Decode keystore
+        if: ${{ inputs.mode == 'release' && inputs.sign && env.HAS_KEYSTORE == 'true' }}
+        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > android/app/sono.jks
+
+      - name: Create key.properties
+        if: ${{ inputs.mode == 'release' && inputs.sign && env.HAS_KEYSTORE == 'true' }}
+        run: |
+          cat > android/key.properties <<EOF
+          storePassword=${{ secrets.KEYSTORE_PASSWORD }}
+          keyPassword=${{ secrets.KEY_PASSWORD }}
+          keyAlias=${{ secrets.KEY_ALIAS }}
+          storeFile=sono.jks
+          EOF
+
+      - name: Warn about unsigned release
+        if: ${{ inputs.mode == 'release' && (!inputs.sign || env.HAS_KEYSTORE != 'true') }}
+        run: echo "::warning::release build without key.properties, the APKs will be unsigned and will not install"
+
+      - name: Build APKs
+        env:
+          FLAVOR: ${{ inputs.flavor }}
+          MODE: ${{ inputs.mode }}
+          BUILD_NAME: ${{ inputs.build_name }}
+          BUILD_NUMBER: ${{ inputs.build_number }}
+        run: |
+          set -euo pipefail
+
+          ARGS=("--$MODE" --flavor "$FLAVOR")
+          if [ -n "$BUILD_NAME" ]; then
+            ARGS+=("--build-name=$BUILD_NAME")
+          fi
+          if [ -n "$BUILD_NUMBER" ]; then
+            ARGS+=("--build-number=$BUILD_NUMBER")
+          fi
+
+          echo "flutter build apk ${ARGS[*]}"
+          flutter build apk "${ARGS[@]}"
+
+      - name: Name the artifact
+        id: meta
+        env:
+          FLAVOR: ${{ inputs.flavor }}
+          MODE: ${{ inputs.mode }}
+        run: |
+          set -euo pipefail
+
+          REF=$(echo "$GITHUB_REF_NAME" | tr '/' '-')
+          SHA=$(git rev-parse --short HEAD)
+          echo "name=sono-$FLAVOR-$MODE-$REF-$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize outputs
+        run: |
+          set -euo pipefail
+
+          {
+            echo "### APKs"
+            echo
+            echo "| file | size |"
+            echo "| --- | --- |"
+            for f in build/app/outputs/flutter-apk/*.apk; do
+              [ -e "$f" ] || continue
+              echo "| $(basename "$f") | $(du -h "$f" | cut -f1) |"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.meta.outputs.name }}
+          path: build/app/outputs/flutter-apk/*.apk
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered Android APK build workflow.
  * Added options to select the build flavor, build mode, signing, and version details.
  * Build results are packaged with descriptive names and retained for 14 days.
  * Added build summaries, translation progress reporting, and warnings for unsigned release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->